### PR TITLE
Fix type/map syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 variable "type-map" {
-  type = map
+  type = map(string)
 
   default = {
     "azurerm_key_vault"                          = "akv"
@@ -45,7 +45,7 @@ variable "type-map" {
 }
 
 variable "env-map" {
-  type = map
+  type = map(string)
 
   default = {
     "d"           = "d"


### PR DESCRIPTION
Update syntax for variables "type-map" and "env-map"

```
variable "[]-map" {
  type = map(string)
}
```
